### PR TITLE
Refine table scan

### DIFF
--- a/dbms/src/Flash/Coprocessor/DAGQueryBlockInterpreter.h
+++ b/dbms/src/Flash/Coprocessor/DAGQueryBlockInterpreter.h
@@ -19,7 +19,6 @@
 #include <Flash/Coprocessor/DAGExpressionAnalyzer.h>
 #include <Flash/Coprocessor/DAGPipeline.h>
 #include <Flash/Coprocessor/RemoteRequest.h>
-#include <Flash/Coprocessor/TiDBStorageTable.h>
 #include <Interpreters/AggregateDescription.h>
 #include <Interpreters/Context.h>
 #include <Interpreters/ExpressionActions.h>
@@ -56,7 +55,7 @@ public:
 
 private:
     void executeImpl(DAGPipeline & pipeline);
-    void handleTableScan(TiDBStorageTable & storage_table, DAGPipeline & pipeline);
+    void handleTableScan(TiDBTableScan && table_scan, DAGPipeline & pipeline);
     void executeCastAfterTableScan(
         const TiDBTableScan & table_scan,
         const std::vector<ExtraCastAfterTSMode> & is_need_add_cast_column,

--- a/dbms/src/Flash/Coprocessor/DAGQueryBlockInterpreter.h
+++ b/dbms/src/Flash/Coprocessor/DAGQueryBlockInterpreter.h
@@ -55,7 +55,7 @@ public:
 
 private:
     void executeImpl(DAGPipeline & pipeline);
-    void handleTableScan(TiDBTableScan && table_scan, DAGPipeline & pipeline);
+    void handleTableScan(const TiDBTableScan & table_scan, DAGPipeline & pipeline);
     void executeCastAfterTableScan(
         const TiDBTableScan & table_scan,
         const std::vector<ExtraCastAfterTSMode> & is_need_add_cast_column,

--- a/dbms/src/Flash/Coprocessor/DAGStorageInterpreter.h
+++ b/dbms/src/Flash/Coprocessor/DAGStorageInterpreter.h
@@ -72,7 +72,7 @@ private:
 
     LearnerReadSnapshot doBatchCopLearnerRead();
 
-    void doLocalRead(const TiDBStorageTable & storage_table, DAGPipeline & pipeline, size_t max_block_size);
+    void buildLocalRead(const TiDBStorageTable & storage_table, DAGPipeline & pipeline, size_t max_block_size);
 
     void buildRemoteRequests(const TiDBStorageTable & storage_table);
 

--- a/dbms/src/Flash/Coprocessor/TiDBStorageTable.h
+++ b/dbms/src/Flash/Coprocessor/TiDBStorageTable.h
@@ -36,12 +36,12 @@ struct StorageWithStructureLock
 
 using IDsAndStorageWithStructureLocks = std::unordered_map<TableID, StorageWithStructureLock>;
 
+// A logical storage object
 class TiDBStorageTable
 {
 public:
     TiDBStorageTable(
-        const tipb::Executor * table_scan_,
-        const String & executor_id_,
+        const TiDBTableScan & table_scan_,
         Context & context_,
         const String & req_id);
 
@@ -49,6 +49,7 @@ public:
     const NamesAndTypes & getSchema() const { return schema; }
     const Names & getScanRequiredColumns() const { return scan_required_columns; }
 
+    void getAndLockStorages();
     void releaseAlterLocks();
 
     // func: void (const TableLockHolder &)
@@ -67,7 +68,6 @@ public:
     Block getSampleBlock() const;
 
 private:
-    IDsAndStorageWithStructureLocks getAndLockStorages(const TiDBTableScan & table_scan);
     NamesAndTypes getSchemaForTableScan(const TiDBTableScan & table_scan);
 
 private:
@@ -82,7 +82,7 @@ private:
     TMTContext & tmt;
     LoggerPtr log;
 
-    TiDBTableScan tidb_table_scan;
+    const TiDBTableScan & tidb_table_scan;
 
     // after `releaseAlterLocks`, all struct lock will call release and move to drop_locks,
     // and then lock_status will change to `alter`.


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Problem Summary:

### What is changed and how it works?

1. Only gets and locks storage(s) after learner read, and add comments about why
2. `DAGQueryBlockInterpreter` does not know about "TiDBStorageTable" except that inside `DAGQueryBlockInterpreter::handleTableScan`, receive a ptr to take over the locks
3. Make the ctor of `TiDBStorageTable` to be more simple, use a static method instead

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
